### PR TITLE
Create components with more that default input count

### DIFF
--- a/lib/circuits/component.rb
+++ b/lib/circuits/component.rb
@@ -8,10 +8,13 @@ module Circuits
   module Component
     # Creates the Component with inputs and outputs
     # @param opts [Hash] options to create the Component with
-    # @option opts [Array<Input>] :inputs The array of inputs to use
+    # @option opts [Array<Input>, FixNum] :inputs The array of inputs to use, or
+    #   the number of inputs to create
     def initialize(opts = {})
-      @inputs = opts[:inputs] ||
-                input_count.times.collect { Circuits::Terminal::Input.new }
+      @inputs = opts[:inputs] if opts[:inputs].is_a? Array
+      @inputs = create_inputs opts[:inputs] if opts[:inputs].is_a? Integer
+      @inputs = create_inputs input_count if opts[:inputs].nil?
+
       @outputs = output_count.times.collect { Circuits::Terminal::Output.new }
       setup
     end
@@ -40,6 +43,17 @@ module Circuits
 
     def output_count
       fail NotImplementedError
+    end
+
+    # Creates an array of N inputs, where N is equal to or greater than the
+    #   default number of inputs for this component
+    # @param n [FixNum] The number of inputs to create
+    # @return [Array<Input>] An array of inputs
+    def create_inputs(n)
+      if n < input_count
+        fail ArgumentError, "Invalid number of inputs, #{self.class} requires at least #{input_count} inputs"
+      end
+      n.times.collect { Circuits::Terminal::Input.new }
     end
 
     def setup

--- a/lib/circuits/component/xnor.rb
+++ b/lib/circuits/component/xnor.rb
@@ -8,7 +8,7 @@ module Circuits
 
       # Sets the output to be the result of a logical XNOR of the inputs
       def tick
-        outputs[0].set(inputs[0].get == inputs[1].get)
+        outputs[0].set(!inputs.map(&:get).inject(:^))
       end
 
       private

--- a/lib/circuits/component/xor.rb
+++ b/lib/circuits/component/xor.rb
@@ -8,7 +8,7 @@ module Circuits
 
       # Sets the output to be the result of a logical XOR of the inputs
       def tick
-        outputs[0].set(inputs[0].get != inputs[1].get)
+        outputs[0].set(inputs.map(&:get).inject(:^))
       end
 
       private

--- a/lib/circuits/version.rb
+++ b/lib/circuits/version.rb
@@ -1,5 +1,5 @@
 # Circuits allows you to express logical circuits in code
 module Circuits
   # The version of the Circuits gem
-  VERSION = '0.2.6'
+  VERSION = '0.3.0'
 end

--- a/spec/unit/circuits/component/and_spec.rb
+++ b/spec/unit/circuits/component/and_spec.rb
@@ -55,5 +55,53 @@ describe Circuits::Component::And do
         end
       end
     end
+
+    [3, 4, 8].each do |n|
+      context "with #{n} inputs" do
+        subject { Circuits::Component::And.new inputs: n }
+
+        before do
+          n.times { |x| subject.inputs[x].set inputs[x] }
+        end
+
+        context 'when all inputs are true' do
+          let(:inputs) { n.times.collect { true } }
+
+          it '= true' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(true)
+          end
+        end
+
+        context 'when all inputs are false' do
+          let(:inputs) { n.times.collect { false } }
+
+          it '= false' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(false)
+          end
+        end
+
+        context 'when any input is false' do
+          n.times do |x|
+            context "when input #{x} is false" do
+              let(:inputs) do
+                inputs =  n.times.collect { true }
+                inputs[x] = false
+                inputs
+              end
+
+              it '= false' do
+                subject.tick
+                subject.tock
+                expect(subject.outputs[0].get).to eq(false)
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/circuits/component/nand_spec.rb
+++ b/spec/unit/circuits/component/nand_spec.rb
@@ -55,5 +55,52 @@ describe Circuits::Component::Nand do
         end
       end
     end
+    [3, 4, 8].each do |n|
+      context "with #{n} inputs" do
+        subject { Circuits::Component::Nand.new inputs: n }
+
+        before do
+          n.times { |x| subject.inputs[x].set inputs[x] }
+        end
+
+        context 'when all inputs are true' do
+          let(:inputs) { n.times.collect { true } }
+
+          it '= false' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(false)
+          end
+        end
+
+        context 'when all inputs are false' do
+          let(:inputs) { n.times.collect { false } }
+
+          it '= true' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(true)
+          end
+        end
+
+        context 'when any input is false' do
+          n.times do |x|
+            context "when input #{x} is false" do
+              let(:inputs) do
+                inputs =  n.times.collect { true }
+                inputs[x] = false
+                inputs
+              end
+
+              it '= true' do
+                subject.tick
+                subject.tock
+                expect(subject.outputs[0].get).to eq(true)
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/circuits/component/nor_spec.rb
+++ b/spec/unit/circuits/component/nor_spec.rb
@@ -55,5 +55,52 @@ describe Circuits::Component::Nor do
         end
       end
     end
+    [3, 4, 8].each do |n|
+      context "with #{n} inputs" do
+        subject { Circuits::Component::Nor.new inputs: n }
+
+        before do
+          n.times { |x| subject.inputs[x].set inputs[x] }
+        end
+
+        context 'when all inputs are true' do
+          let(:inputs) { n.times.collect { true } }
+
+          it '= false' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(false)
+          end
+        end
+
+        context 'when all inputs are false' do
+          let(:inputs) { n.times.collect { false } }
+
+          it '= true' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(true)
+          end
+        end
+
+        context 'when any input is false' do
+          n.times do |x|
+            context "when input #{x} is false" do
+              let(:inputs) do
+                inputs =  n.times.collect { true }
+                inputs[x] = false
+                inputs
+              end
+
+              it '= false' do
+                subject.tick
+                subject.tock
+                expect(subject.outputs[0].get).to eq(false)
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/circuits/component/or_spec.rb
+++ b/spec/unit/circuits/component/or_spec.rb
@@ -55,5 +55,52 @@ describe Circuits::Component::Or do
         end
       end
     end
+    [3, 4, 8].each do |n|
+      context "with #{n} inputs" do
+        subject { Circuits::Component::Or.new inputs: n }
+
+        before do
+          n.times { |x| subject.inputs[x].set inputs[x] }
+        end
+
+        context 'when all inputs are true' do
+          let(:inputs) { n.times.collect { true } }
+
+          it '= true' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(true)
+          end
+        end
+
+        context 'when all inputs are false' do
+          let(:inputs) { n.times.collect { false } }
+
+          it '= false' do
+            subject.tick
+            subject.tock
+            expect(subject.outputs[0].get).to eq(false)
+          end
+        end
+
+        context 'when any input is false' do
+          n.times do |x|
+            context "when input #{x} is false" do
+              let(:inputs) do
+                inputs =  n.times.collect { true }
+                inputs[x] = false
+                inputs
+              end
+
+              it '= true' do
+                subject.tick
+                subject.tock
+                expect(subject.outputs[0].get).to eq(true)
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/circuits/component/xnor_spec.rb
+++ b/spec/unit/circuits/component/xnor_spec.rb
@@ -55,5 +55,121 @@ describe Circuits::Component::Xnor do
         end
       end
     end
+    context 'when the number of inputs is even' do
+      [2, 4, 8].each do |n|
+        context "with #{n} inputs" do
+          subject { Circuits::Component::Xnor.new inputs: n }
+
+          before do
+            n.times { |x| subject.inputs[x].set inputs[x] }
+          end
+
+          context 'when all inputs are true' do
+            let(:inputs) { n.times.collect { true } }
+
+            it '= true' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(true)
+            end
+          end
+
+          context 'when all inputs are false' do
+            let(:inputs) { n.times.collect { false } }
+
+            it '= true' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(true)
+            end
+          end
+
+          context 'when any input is false' do
+            n.times do |x|
+              context "when input #{x} is false" do
+                let(:inputs) do
+                  inputs =  n.times.collect { true }
+                  inputs[x] = false
+                  inputs
+                end
+
+                it '= false' do
+                  subject.tick
+                  subject.tock
+                  expect(subject.outputs[0].get).to eq(false)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    context 'when the number of inputs is odd' do
+      [3, 5, 7].each do |n|
+        context "with #{n} inputs" do
+          subject { Circuits::Component::Xnor.new inputs: n }
+
+          before do
+            n.times { |x| subject.inputs[x].set inputs[x] }
+          end
+
+          context 'when all inputs are true' do
+            let(:inputs) { n.times.collect { true } }
+
+            it '= false' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(false)
+            end
+          end
+
+          context 'when all inputs are false' do
+            let(:inputs) { n.times.collect { false } }
+
+            it '= true' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(true)
+            end
+          end
+
+          context 'when any input is false' do
+            n.times do |x|
+              context "when input #{x} is false" do
+                let(:inputs) do
+                  inputs =  n.times.collect { true }
+                  inputs[x] = false
+                  inputs
+                end
+
+                it '= true' do
+                  subject.tick
+                  subject.tock
+                  expect(subject.outputs[0].get).to eq(true)
+                end
+              end
+            end
+          end
+
+          context 'when any input is true' do
+            n.times do |x|
+              context "when input #{x} is true" do
+                let(:inputs) do
+                  inputs =  n.times.collect { false }
+                  inputs[x] = true
+                  inputs
+                end
+
+                it '= false' do
+                  subject.tick
+                  subject.tock
+                  expect(subject.outputs[0].get).to eq(false)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/circuits/component/xor_spec.rb
+++ b/spec/unit/circuits/component/xor_spec.rb
@@ -55,5 +55,121 @@ describe Circuits::Component::Xor do
         end
       end
     end
+    context 'when the number of inputs is even' do
+      [2, 4, 8].each do |n|
+        context "with #{n} inputs" do
+          subject { Circuits::Component::Xor.new inputs: n }
+
+          before do
+            n.times { |x| subject.inputs[x].set inputs[x] }
+          end
+
+          context 'when all inputs are true' do
+            let(:inputs) { n.times.collect { true } }
+
+            it '= false' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(false)
+            end
+          end
+
+          context 'when all inputs are false' do
+            let(:inputs) { n.times.collect { false } }
+
+            it '= false' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(false)
+            end
+          end
+
+          context 'when any input is false' do
+            n.times do |x|
+              context "when input #{x} is false" do
+                let(:inputs) do
+                  inputs =  n.times.collect { true }
+                  inputs[x] = false
+                  inputs
+                end
+
+                it '= true' do
+                  subject.tick
+                  subject.tock
+                  expect(subject.outputs[0].get).to eq(true)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    context 'when the number of inputs is odd' do
+      [3, 5, 7].each do |n|
+        context "with #{n} inputs" do
+          subject { Circuits::Component::Xor.new inputs: n }
+
+          before do
+            n.times { |x| subject.inputs[x].set inputs[x] }
+          end
+
+          context 'when all inputs are true' do
+            let(:inputs) { n.times.collect { true } }
+
+            it '= true' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(true)
+            end
+          end
+
+          context 'when all inputs are false' do
+            let(:inputs) { n.times.collect { false } }
+
+            it '= false' do
+              subject.tick
+              subject.tock
+              expect(subject.outputs[0].get).to eq(false)
+            end
+          end
+
+          context 'when any input is false' do
+            n.times do |x|
+              context "when input #{x} is false" do
+                let(:inputs) do
+                  inputs =  n.times.collect { true }
+                  inputs[x] = false
+                  inputs
+                end
+
+                it '= false' do
+                  subject.tick
+                  subject.tock
+                  expect(subject.outputs[0].get).to eq(false)
+                end
+              end
+            end
+          end
+
+          context 'when any input is true' do
+            n.times do |x|
+              context "when input #{x} is true" do
+                let(:inputs) do
+                  inputs =  n.times.collect { false }
+                  inputs[x] = true
+                  inputs
+                end
+
+                it '= true' do
+                  subject.tick
+                  subject.tock
+                  expect(subject.outputs[0].get).to eq(true)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/circuits/component_spec.rb
+++ b/spec/unit/circuits/component_spec.rb
@@ -16,11 +16,15 @@ class MockComponent
   def mock_output_count
     output_count
   end
+
+  def mock_create_inputs(n)
+    create_inputs(n)
+  end
 end
 
 describe Circuits::Component do
   let(:outputs) { [double('output')] }
-  
+
   subject { MockComponent.new(outputs: outputs) }
 
   describe '#input_count' do
@@ -45,6 +49,26 @@ describe Circuits::Component do
     it 'tocks the outputs' do
       expect(outputs[0]).to receive(:tock)
       subject.tock
+    end
+  end
+
+  describe '#create_inputs' do
+    before :each do
+      allow(subject).to receive(:input_count).and_return(2)
+    end
+
+    context 'when the given argument is less than the value of input count' do
+      it 'fails with an argument error' do
+        expect { subject.mock_create_inputs(0) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when given a valid number of inputs' do
+      [2, 4, 6].each do |n|
+        it "creates #{n} inputs" do
+          expect(subject.mock_create_inputs(n).size).to eq(n)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This closes #7 

If the `:inputs` option is passed to a component constructor, and it contains an `Integer` instead of an `Array` the it will create that many inputs on the component.