### PR TITLE
Improve local development by adding linting tasks

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--format doc
 --require spec_helper

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+require 'reek/rake/task'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -11,3 +12,7 @@ RuboCop::RakeTask.new(:rubocop) do |task|
   # only show the files with failures
   task.formatters = ['files']
 end
+
+Reek::Rake::Task.new
+
+task lint: [:rubocop, :reek]

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'reek/rake/task'
+require 'yard'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -16,3 +17,7 @@ end
 Reek::Rake::Task.new
 
 task lint: [:rubocop, :reek]
+
+YARD::Rake::YardocTask.new(:yard) do |t|
+  t.stats_options = ['--list-undoc']
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,13 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.patterns = ['lib/**/*.rb']
+  # only show the files with failures
+  task.formatters = ['files']
+end

--- a/circuits.gemspec
+++ b/circuits.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
+  spec.add_development_dependency 'rubocop', '~> 0.34'
 end

--- a/circuits.gemspec
+++ b/circuits.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'rubocop', '~> 0.34'
+  spec.add_development_dependency 'reek', '~> 3.5'
 end

--- a/circuits.gemspec
+++ b/circuits.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'rubocop', '~> 0.34'
   spec.add_development_dependency 'reek', '~> 3.5'
+  spec.add_development_dependency 'yard', '~> 0.8.7'
 end


### PR DESCRIPTION
Added rubocop, and reek as development dependencies and set up rake tasks for them.

Also added Yard as a dependency and created a rake task for that.

I have left them out of the default task because they are quite strict and would cause Travis to fail