### PR TITLE
Can access component terminals with []

### DIFF
--- a/lib/circuits/component.rb
+++ b/lib/circuits/component.rb
@@ -11,11 +11,10 @@ module Circuits
     # @option opts [Array<Input>, FixNum] :inputs The array of inputs to use, or
     #   the number of inputs to create
     def initialize(opts = {})
-      @inputs = opts[:inputs] if opts[:inputs].is_a? Array
-      @inputs = create_inputs opts[:inputs] if opts[:inputs].is_a? Integer
-      @inputs = create_inputs input_count if opts[:inputs].nil?
-
-      @outputs = output_count.times.collect { Circuits::Terminal::Output.new }
+      set_defaults
+      create_inputs opts
+      create_outputs opts
+      create_port_mappings
       setup
     end
 
@@ -29,6 +28,33 @@ module Circuits
       outputs.each(&:tock)
     end
 
+    # Gets the teminal assigned to the port
+    # @param port [Symbol] The symbol that represents the terminal
+    # @return [Input, Output] The terminal
+    def [](port)
+      p = @port_mappings[port]
+      case p[:type]
+      when :input
+        @inputs[p[:number]]
+      when :output
+        @outputs[p[:number]]
+      end
+    end
+
+    # Assigns to an input or output
+    # @param port [Symbol] The symbol that represents the terminal
+    # @param terminal [Input, Output] The terminal to assign
+    # @return [Input, Output] The terminal that was passed in
+    def []=(port, terminal)
+      p = @port_mappings[port]
+      case p[:type]
+      when :input
+        @inputs[p[:number]] = terminal
+      when :output
+        @outputs[p[:number]] = terminal
+      end
+    end
+
     # the inputs of this component
     attr_reader :inputs
 
@@ -37,23 +63,56 @@ module Circuits
 
     private
 
-    def input_count
-      fail NotImplementedError
-    end
-
-    def output_count
-      fail NotImplementedError
-    end
-
-    # Creates an array of N inputs, where N is equal to or greater than the
-    #   default number of inputs for this component
-    # @param n [FixNum] The number of inputs to create
-    # @return [Array<Input>] An array of inputs
-    def create_inputs(n)
-      if n < input_count
-        fail ArgumentError, "Invalid number of inputs, #{self.class} requires at least #{input_count} inputs"
+    def create_inputs(opts)
+      if opts[:inputs].class == Array
+        @inputs = opts[:inputs]
+        @input_count = @inputs.count
+      elsif opts[:inputs].class == Fixnum
+        @input_count = opts[:inputs]
       end
-      n.times.collect { Circuits::Terminal::Input.new }
+      @inputs ||= @input_count.times.collect { Circuits::Terminal::Input.new }
+    end
+
+    def create_outputs(opts)
+      if opts[:outputs].class == Array
+        @outputs = opts[:outputs]
+        @output_count = @output.length
+      elsif opts[:outputs].class == Fixnum
+        @output_count = opts[:outputs]
+      end
+      @outputs ||= @output_count.times.collect do
+        Circuits::Terminal::Output.new
+      end
+    end
+
+    def create_port_mappings
+      return @port_mappings unless @port_mappings.nil?
+      @port_mappings = {}
+      input_mappings.each { |x| @port_mappings.merge!(x) }
+      output_mappings.each { |x| @port_mappings.merge!(x) }
+      @port_mappings
+    end
+
+    def input_mappings
+      return [{ in: { type: :input, number: 0 } }] if @input_count == 1
+      @input_count.times.collect do |i|
+        { num_to_port(i) =>  { type: :input, number: i } }
+      end
+    end
+
+    def output_mappings
+      return[{ out: { type: :output, number: 0 } }] if @output_count == 1
+      @output_count.times.collect do |i|
+        { num_to_port(i + @input_count) =>  { type: :output, number: i } }
+      end
+    end
+
+    def num_to_port(i)
+      (i + 'a'.ord).chr.to_sym
+    end
+
+    def set_defaults
+      fail NotImplementedError
     end
 
     def setup

--- a/lib/circuits/component.rb
+++ b/lib/circuits/component.rb
@@ -66,7 +66,7 @@ module Circuits
     def create_inputs(opts)
       if opts[:inputs].class == Array
         @inputs = opts[:inputs]
-        @input_count = @inputs.count
+        @input_count = @inputs.length
       elsif opts[:inputs].class == Fixnum
         @input_count = opts[:inputs]
       end
@@ -76,7 +76,7 @@ module Circuits
     def create_outputs(opts)
       if opts[:outputs].class == Array
         @outputs = opts[:outputs]
-        @output_count = @output.length
+        @output_count = @outputs.length
       elsif opts[:outputs].class == Fixnum
         @output_count = opts[:outputs]
       end

--- a/lib/circuits/component/and.rb
+++ b/lib/circuits/component/and.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        2
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 2
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/component/nand.rb
+++ b/lib/circuits/component/nand.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        2
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 2
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/component/nor.rb
+++ b/lib/circuits/component/nor.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        2
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 2
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/component/not.rb
+++ b/lib/circuits/component/not.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        1
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 1
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/component/or.rb
+++ b/lib/circuits/component/or.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        2
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 2
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/component/sr_nand.rb
+++ b/lib/circuits/component/sr_nand.rb
@@ -12,28 +12,33 @@ module Circuits
           sub_components.each(&:tick)
           sub_components.each(&:tock)
         end
-        outputs[0].set nor_1.outputs[0].get
-        outputs[1].set nor_2.outputs[0].get
+        self[:q].set nand_1[:out].get
+        self[:not_q].set nand_2[:out].get
       end
 
       private
 
-      attr_reader :nor_1, :nor_2, :sub_components
+      attr_reader :nand_1, :nand_2, :sub_components
 
-      def input_count
-        2
-      end
-
-      def output_count
-        2
+      def set_defaults
+        @input_count = 2
+        @output_count = 2
+        @port_mappings = {
+          not_s: { type: :input, number: 0 },
+          not_r: { type: :input, number: 1 },
+          q: { type: :output, number: 0 },
+          not_q: { type: :output, number: 1 }
+        }
       end
 
       def setup
-        @nor_1 = Nand.new(inputs: [inputs[0]])
-        @nor_2 = Nand.new(inputs: [inputs[1]])
-        @sub_components = [@nor_1, @nor_2]
-        nor_1.inputs << nor_2.outputs[0]
-        nor_2.inputs << nor_1.outputs[0]
+        @nand_1 = Nand.new
+        @nand_2 = Nand.new
+        @sub_components = [@nand_1, @nand_2]
+        nand_1[:a] = self[:not_s]
+        nand_2[:a] = self[:not_r]
+        nand_1[:b] = nand_2[:out]
+        nand_2[:b] = nand_1[:out]
       end
     end
   end

--- a/lib/circuits/component/sr_nor.rb
+++ b/lib/circuits/component/sr_nor.rb
@@ -12,28 +12,33 @@ module Circuits
           sub_components.each(&:tick)
           sub_components.each(&:tock)
         end
-        outputs[0].set nor_1.outputs[0].get
-        outputs[1].set nor_2.outputs[0].get
+        self[:q].set nor_1[:out].get
+        self[:not_q].set nor_2[:out].get
       end
 
       private
 
       attr_reader :nor_1, :nor_2, :sub_components
 
-      def input_count
-        2
-      end
-
-      def output_count
-        2
+      def set_defaults
+        @input_count = 2
+        @output_count = 2
+        @port_mappings = {
+          r: { type: :input, number: 0 },
+          s: { type: :input, number: 1 },
+          q: { type: :output, number: 0 },
+          not_q: { type: :output, number: 1 }
+        }
       end
 
       def setup
-        @nor_1 = Nor.new(inputs: [inputs[0]])
-        @nor_2 = Nor.new(inputs: [inputs[1]])
+        @nor_1 = Nor.new
+        @nor_2 = Nor.new
         @sub_components = [@nor_1, @nor_2]
-        nor_1.inputs << nor_2.outputs[0]
-        nor_2.inputs << nor_1.outputs[0]
+        nor_1[:a] = self[:r]
+        nor_2[:a] = self[:s]
+        nor_1[:b] = nor_2[:out]
+        nor_2[:b] = nor_1[:out]
       end
     end
   end

--- a/lib/circuits/component/xnor.rb
+++ b/lib/circuits/component/xnor.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        2
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 2
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/component/xor.rb
+++ b/lib/circuits/component/xor.rb
@@ -13,12 +13,9 @@ module Circuits
 
       private
 
-      def input_count
-        2
-      end
-
-      def output_count
-        1
+      def set_defaults
+        @input_count = 2
+        @output_count = 1
       end
     end
   end

--- a/lib/circuits/terminal.rb
+++ b/lib/circuits/terminal.rb
@@ -1,6 +1,5 @@
 module Circuits
   # A terminal holds a logical state, it can be attatched to components
   module Terminal
-
   end
 end

--- a/lib/circuits/version.rb
+++ b/lib/circuits/version.rb
@@ -1,5 +1,5 @@
 # Circuits allows you to express logical circuits in code
 module Circuits
   # The version of the Circuits gem
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/unit/circuits/component/and_spec.rb
+++ b/spec/unit/circuits/component/and_spec.rb
@@ -7,8 +7,8 @@ describe Circuits::Component::And do
       subject { Circuits::Component::And.new }
 
       before do
-        subject.inputs[0].set input_1
-        subject.inputs[1].set input_2
+        subject[:a].set input_1
+        subject[:b].set input_2
       end
 
       context 'false + false' do
@@ -18,7 +18,7 @@ describe Circuits::Component::And do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -29,7 +29,7 @@ describe Circuits::Component::And do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -40,7 +40,7 @@ describe Circuits::Component::And do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -51,7 +51,7 @@ describe Circuits::Component::And do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
     end
@@ -70,7 +70,7 @@ describe Circuits::Component::And do
           it '= true' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(true)
+            expect(subject[:out].get).to eq(true)
           end
         end
 
@@ -80,7 +80,7 @@ describe Circuits::Component::And do
           it '= false' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(false)
+            expect(subject[:out].get).to eq(false)
           end
         end
 
@@ -96,7 +96,7 @@ describe Circuits::Component::And do
               it '= false' do
                 subject.tick
                 subject.tock
-                expect(subject.outputs[0].get).to eq(false)
+                expect(subject[:out].get).to eq(false)
               end
             end
           end

--- a/spec/unit/circuits/component/nand_spec.rb
+++ b/spec/unit/circuits/component/nand_spec.rb
@@ -7,8 +7,8 @@ describe Circuits::Component::Nand do
       subject { Circuits::Component::Nand.new }
 
       before do
-        subject.inputs[0].set input_1
-        subject.inputs[1].set input_2
+        subject[:a].set input_1
+        subject[:b].set input_2
       end
 
       context 'false + false' do
@@ -18,7 +18,7 @@ describe Circuits::Component::Nand do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -29,7 +29,7 @@ describe Circuits::Component::Nand do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -40,7 +40,7 @@ describe Circuits::Component::Nand do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -51,7 +51,7 @@ describe Circuits::Component::Nand do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
     end
@@ -69,7 +69,7 @@ describe Circuits::Component::Nand do
           it '= false' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(false)
+            expect(subject[:out].get).to eq(false)
           end
         end
 
@@ -79,7 +79,7 @@ describe Circuits::Component::Nand do
           it '= true' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(true)
+            expect(subject[:out].get).to eq(true)
           end
         end
 
@@ -95,7 +95,7 @@ describe Circuits::Component::Nand do
               it '= true' do
                 subject.tick
                 subject.tock
-                expect(subject.outputs[0].get).to eq(true)
+                expect(subject[:out].get).to eq(true)
               end
             end
           end

--- a/spec/unit/circuits/component/nor_spec.rb
+++ b/spec/unit/circuits/component/nor_spec.rb
@@ -7,8 +7,8 @@ describe Circuits::Component::Nor do
       subject { Circuits::Component::Nor.new }
 
       before do
-        subject.inputs[0].set input_1
-        subject.inputs[1].set input_2
+        subject[:a].set input_1
+        subject[:b].set input_2
       end
 
       context 'false + false' do
@@ -18,7 +18,7 @@ describe Circuits::Component::Nor do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -29,7 +29,7 @@ describe Circuits::Component::Nor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -40,7 +40,7 @@ describe Circuits::Component::Nor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -51,7 +51,7 @@ describe Circuits::Component::Nor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
     end
@@ -69,7 +69,7 @@ describe Circuits::Component::Nor do
           it '= false' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(false)
+            expect(subject[:out].get).to eq(false)
           end
         end
 
@@ -79,7 +79,7 @@ describe Circuits::Component::Nor do
           it '= true' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(true)
+            expect(subject[:out].get).to eq(true)
           end
         end
 
@@ -95,7 +95,7 @@ describe Circuits::Component::Nor do
               it '= false' do
                 subject.tick
                 subject.tock
-                expect(subject.outputs[0].get).to eq(false)
+                expect(subject[:out].get).to eq(false)
               end
             end
           end

--- a/spec/unit/circuits/component/not_spec.rb
+++ b/spec/unit/circuits/component/not_spec.rb
@@ -5,7 +5,7 @@ describe Circuits::Component::Not do
   describe '#tick' do
     subject { Circuits::Component::Not.new }
 
-    before { subject.inputs[0].set input }
+    before { subject[:in].set input }
 
     context '!false' do
       let(:input) { false }
@@ -13,7 +13,7 @@ describe Circuits::Component::Not do
       it '= true' do
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(true)
+        expect(subject[:out].get).to eq(true)
       end
     end
 
@@ -23,7 +23,7 @@ describe Circuits::Component::Not do
       it '= false' do
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(false)
+        expect(subject[:out].get).to eq(false)
       end
     end
   end

--- a/spec/unit/circuits/component/or_spec.rb
+++ b/spec/unit/circuits/component/or_spec.rb
@@ -7,8 +7,8 @@ describe Circuits::Component::Or do
       subject { Circuits::Component::Or.new }
 
       before do
-        subject.inputs[0].set input_1
-        subject.inputs[1].set input_2
+        subject[:a].set input_1
+        subject[:b].set input_2
       end
 
       context 'false + false' do
@@ -18,7 +18,7 @@ describe Circuits::Component::Or do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -29,7 +29,7 @@ describe Circuits::Component::Or do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -40,7 +40,7 @@ describe Circuits::Component::Or do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -51,7 +51,7 @@ describe Circuits::Component::Or do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
     end
@@ -69,7 +69,7 @@ describe Circuits::Component::Or do
           it '= true' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(true)
+            expect(subject[:out].get).to eq(true)
           end
         end
 
@@ -79,7 +79,7 @@ describe Circuits::Component::Or do
           it '= false' do
             subject.tick
             subject.tock
-            expect(subject.outputs[0].get).to eq(false)
+            expect(subject[:out].get).to eq(false)
           end
         end
 
@@ -95,7 +95,7 @@ describe Circuits::Component::Or do
               it '= true' do
                 subject.tick
                 subject.tock
-                expect(subject.outputs[0].get).to eq(true)
+                expect(subject[:out].get).to eq(true)
               end
             end
           end

--- a/spec/unit/circuits/component/sr_nand_spec.rb
+++ b/spec/unit/circuits/component/sr_nand_spec.rb
@@ -7,61 +7,61 @@ describe Circuits::Component::SrNand do
 
     context 'is set' do
       before do
-        subject.inputs[0].set false
-        subject.inputs[1].set true
+        subject[:not_s].set false
+        subject[:not_r].set true
         subject.tick
         subject.tock
-        subject.inputs[0].set true
+        subject[:not_s].set true
       end
 
       it 'is set' do
-        expect(subject.outputs[0].get).to eq(true)
-        expect(subject.outputs[1].get).to eq(false)
+        expect(subject[:q].get).to eq(true)
+        expect(subject[:not_q].get).to eq(false)
       end
 
       it 'is stable' do
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(true)
-        expect(subject.outputs[1].get).to eq(false)
+        expect(subject[:q].get).to eq(true)
+        expect(subject[:not_q].get).to eq(false)
       end
 
       it 'can be reset' do
-        subject.inputs[1].set false
+        subject[:not_r].set false
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(false)
-        expect(subject.outputs[1].get).to eq(true)
+        expect(subject[:q].get).to eq(false)
+        expect(subject[:not_q].get).to eq(true)
       end
     end
 
     context 'is reset' do
       before do
-        subject.inputs[0].set true
-        subject.inputs[1].set false
+        subject[:not_s].set true
+        subject[:not_r].set false
         subject.tick
         subject.tock
-        subject.inputs[1].set true
+        subject[:not_r].set true
       end
 
       it 'is reset' do
-        expect(subject.outputs[0].get).to eq(false)
-        expect(subject.outputs[1].get).to eq(true)
+        expect(subject[:q].get).to eq(false)
+        expect(subject[:not_q].get).to eq(true)
       end
 
       it 'is stable' do
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(false)
-        expect(subject.outputs[1].get).to eq(true)
+        expect(subject[:q].get).to eq(false)
+        expect(subject[:not_q].get).to eq(true)
       end
 
       it 'can be set' do
-        subject.inputs[0].set false
+        subject[:not_s].set false
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(true)
-        expect(subject.outputs[1].get).to eq(false)
+        expect(subject[:q].get).to eq(true)
+        expect(subject[:not_q].get).to eq(false)
       end
     end
   end

--- a/spec/unit/circuits/component/sr_nor_spec.rb
+++ b/spec/unit/circuits/component/sr_nor_spec.rb
@@ -7,61 +7,61 @@ describe Circuits::Component::SrNor do
 
     context 'is set' do
       before do
-        subject.inputs[0].set false
-        subject.inputs[1].set true
+        subject[:r].set false
+        subject[:s].set true
         subject.tick
         subject.tock
-        subject.inputs[1].set false
+        subject[:s].set false
       end
 
       it 'is set' do
-        expect(subject.outputs[0].get).to eq(true)
-        expect(subject.outputs[1].get).to eq(false)
+        expect(subject[:q].get).to eq(true)
+        expect(subject[:not_q].get).to eq(false)
       end
 
       it 'is stable' do
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(true)
-        expect(subject.outputs[1].get).to eq(false)
+        expect(subject[:q].get).to eq(true)
+        expect(subject[:not_q].get).to eq(false)
       end
 
       it 'can be reset' do
-        subject.inputs[0].set true
+        subject[:r].set true
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(false)
-        expect(subject.outputs[1].get).to eq(true)
+        expect(subject[:q].get).to eq(false)
+        expect(subject[:not_q].get).to eq(true)
       end
     end
 
     context 'is reset' do
       before do
-        subject.inputs[0].set true
-        subject.inputs[1].set false
+        subject[:r].set true
+        subject[:s].set false
         subject.tick
         subject.tock
-        subject.inputs[0].set false
+        subject[:r].set false
       end
 
       it 'is reset' do
-        expect(subject.outputs[0].get).to eq(false)
-        expect(subject.outputs[1].get).to eq(true)
+        expect(subject[:q].get).to eq(false)
+        expect(subject[:not_q].get).to eq(true)
       end
 
       it 'is stable' do
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(false)
-        expect(subject.outputs[1].get).to eq(true)
+        expect(subject[:q].get).to eq(false)
+        expect(subject[:not_q].get).to eq(true)
       end
 
       it 'can be set' do
-        subject.inputs[1].set true
+        subject[:s].set true
         subject.tick
         subject.tock
-        expect(subject.outputs[0].get).to eq(true)
-        expect(subject.outputs[1].get).to eq(false)
+        expect(subject[:q].get).to eq(true)
+        expect(subject[:not_q].get).to eq(false)
       end
     end
   end

--- a/spec/unit/circuits/component/xnor_spec.rb
+++ b/spec/unit/circuits/component/xnor_spec.rb
@@ -7,8 +7,8 @@ describe Circuits::Component::Xnor do
       subject { Circuits::Component::Xnor.new }
 
       before do
-        subject.inputs[0].set input_1
-        subject.inputs[1].set input_2
+        subject[:a].set input_1
+        subject[:b].set input_2
       end
 
       context 'false + false' do
@@ -18,7 +18,7 @@ describe Circuits::Component::Xnor do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -29,7 +29,7 @@ describe Circuits::Component::Xnor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -40,7 +40,7 @@ describe Circuits::Component::Xnor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -51,7 +51,7 @@ describe Circuits::Component::Xnor do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
     end
@@ -70,7 +70,7 @@ describe Circuits::Component::Xnor do
             it '= true' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(true)
+              expect(subject[:out].get).to eq(true)
             end
           end
 
@@ -80,7 +80,7 @@ describe Circuits::Component::Xnor do
             it '= true' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(true)
+              expect(subject[:out].get).to eq(true)
             end
           end
 
@@ -96,7 +96,7 @@ describe Circuits::Component::Xnor do
                 it '= false' do
                   subject.tick
                   subject.tock
-                  expect(subject.outputs[0].get).to eq(false)
+                  expect(subject[:out].get).to eq(false)
                 end
               end
             end
@@ -119,7 +119,7 @@ describe Circuits::Component::Xnor do
             it '= false' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(false)
+              expect(subject[:out].get).to eq(false)
             end
           end
 
@@ -129,7 +129,7 @@ describe Circuits::Component::Xnor do
             it '= true' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(true)
+              expect(subject[:out].get).to eq(true)
             end
           end
 
@@ -145,7 +145,7 @@ describe Circuits::Component::Xnor do
                 it '= true' do
                   subject.tick
                   subject.tock
-                  expect(subject.outputs[0].get).to eq(true)
+                  expect(subject[:out].get).to eq(true)
                 end
               end
             end
@@ -163,7 +163,7 @@ describe Circuits::Component::Xnor do
                 it '= false' do
                   subject.tick
                   subject.tock
-                  expect(subject.outputs[0].get).to eq(false)
+                  expect(subject[:out].get).to eq(false)
                 end
               end
             end

--- a/spec/unit/circuits/component/xor_spec.rb
+++ b/spec/unit/circuits/component/xor_spec.rb
@@ -7,8 +7,8 @@ describe Circuits::Component::Xor do
       subject { Circuits::Component::Xor.new }
 
       before do
-        subject.inputs[0].set input_1
-        subject.inputs[1].set input_2
+        subject[:a].set input_1
+        subject[:b].set input_2
       end
 
       context 'false + false' do
@@ -18,7 +18,7 @@ describe Circuits::Component::Xor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
 
@@ -29,7 +29,7 @@ describe Circuits::Component::Xor do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -40,7 +40,7 @@ describe Circuits::Component::Xor do
         it '= true' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(true)
+          expect(subject[:out].get).to eq(true)
         end
       end
 
@@ -51,7 +51,7 @@ describe Circuits::Component::Xor do
         it '= false' do
           subject.tick
           subject.tock
-          expect(subject.outputs[0].get).to eq(false)
+          expect(subject[:out].get).to eq(false)
         end
       end
     end
@@ -70,7 +70,7 @@ describe Circuits::Component::Xor do
             it '= false' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(false)
+              expect(subject[:out].get).to eq(false)
             end
           end
 
@@ -80,7 +80,7 @@ describe Circuits::Component::Xor do
             it '= false' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(false)
+              expect(subject[:out].get).to eq(false)
             end
           end
 
@@ -96,7 +96,7 @@ describe Circuits::Component::Xor do
                 it '= true' do
                   subject.tick
                   subject.tock
-                  expect(subject.outputs[0].get).to eq(true)
+                  expect(subject[:out].get).to eq(true)
                 end
               end
             end
@@ -119,7 +119,7 @@ describe Circuits::Component::Xor do
             it '= true' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(true)
+              expect(subject[:out].get).to eq(true)
             end
           end
 
@@ -129,7 +129,7 @@ describe Circuits::Component::Xor do
             it '= false' do
               subject.tick
               subject.tock
-              expect(subject.outputs[0].get).to eq(false)
+              expect(subject[:out].get).to eq(false)
             end
           end
 
@@ -145,7 +145,7 @@ describe Circuits::Component::Xor do
                 it '= false' do
                   subject.tick
                   subject.tock
-                  expect(subject.outputs[0].get).to eq(false)
+                  expect(subject[:out].get).to eq(false)
                 end
               end
             end
@@ -163,7 +163,7 @@ describe Circuits::Component::Xor do
                 it '= true' do
                   subject.tick
                   subject.tock
-                  expect(subject.outputs[0].get).to eq(true)
+                  expect(subject[:out].get).to eq(true)
                 end
               end
             end

--- a/spec/unit/circuits/component_spec.rb
+++ b/spec/unit/circuits/component_spec.rb
@@ -2,43 +2,113 @@ require 'spec_helper'
 require 'circuits/component'
 
 # Mock component to include Circuits::Component for function accessability
-class MockComponent
+class MockComponent1
   include Circuits::Component
 
-  def initialize(opts = {})
-    @outputs = opts[:outputs]
-  end
-
-  def mock_set_defaults
-    set_defaults
-  end
-
-  def mock_create_inputs(n)
-    create_inputs(n)
+  def set_defaults
+    @input_count = 1
+    @output_count = 1
   end
 end
 
+# Mock component to include Circuits::Component for function accessability
+class MockComponent2
+  include Circuits::Component
+end
+
 describe Circuits::Component do
-  let(:outputs) { [double('output')] }
+  context 'when using defaults' do
+    subject { MockComponent1.new }
 
-  subject { MockComponent.new(outputs: outputs) }
+    it 'has one input' do
+      expect(subject.inputs.count).to eq(1)
+    end
 
-  describe '#set_defaults' do
-    it 'is not implemented' do
-      expect { subject.mock_set_defaults }.to raise_error(NotImplementedError)
+    it 'has one output' do
+      expect(subject.outputs.count).to eq(1)
+    end
+
+    describe '#[]=' do
+      let(:new_input) { double('new_input') }
+      let(:new_output) { double('new_output') }
+
+      before do
+        subject[:in] = new_input
+        subject[:out] = new_output
+      end
+
+      it 'has the new input available as :in' do
+        expect(subject[:in]).to eq(new_input)
+      end
+
+      it 'has the new output available as :out' do
+        expect(subject[:out]).to eq(new_output)
+      end
     end
   end
 
-  describe '#tick' do
-    it 'is not implemented' do
-      expect { subject.tick }.to raise_error(NotImplementedError)
+  context 'when specifying input and output count' do
+    subject { MockComponent1.new(inputs: 2, outputs: 2) }
+
+    it 'has one input' do
+      expect(subject.inputs.count).to eq(2)
+    end
+
+    it 'has one output' do
+      expect(subject.outputs.count).to eq(2)
     end
   end
 
-  describe '#tock' do
-    it 'tocks the outputs' do
-      expect(outputs[0]).to receive(:tock)
-      subject.tock
+  context 'when supplying inputs and outputs' do
+    let(:inputs) { [double('input')] }
+    let(:outputs) { [double('output')] }
+
+    subject { MockComponent1.new(inputs: inputs, outputs: outputs) }
+
+    describe '#tick' do
+      it 'raises NotImplementedError' do
+        expect { subject.tick }.to raise_error(NotImplementedError)
+      end
+    end
+
+    describe '#tock' do
+      it 'tocks the outputs' do
+        expect(outputs[0]).to receive(:tock)
+        subject.tock
+      end
+    end
+
+    describe '#[]' do
+      context 'one input and one output' do
+        it 'has the input available as :in' do
+          expect(subject[:in]).to eq(inputs[0])
+        end
+
+        it 'has the output available as :out' do
+          expect(subject[:out]).to eq(outputs[0])
+        end
+      end
+
+      context 'two inputs and two outputs' do
+        let(:inputs) { [double('input_1'), double('input_2')] }
+        let(:outputs) { [double('output_1'), double('output_2')] }
+
+        it 'has the inputs available as :a and :b' do
+          expect(subject[:a]).to eq(inputs[0])
+          expect(subject[:b]).to eq(inputs[1])
+        end
+
+        it 'has the outputs available as :c and :d' do
+          expect(subject[:c]).to eq(outputs[0])
+          expect(subject[:d]).to eq(outputs[1])
+        end
+      end
+    end
+  end
+
+  context 'when you do not override #set_defaults' do
+    it 'raises NotImplementedError' do
+      expect { MockComponent2.new }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/unit/circuits/component_spec.rb
+++ b/spec/unit/circuits/component_spec.rb
@@ -9,12 +9,8 @@ class MockComponent
     @outputs = opts[:outputs]
   end
 
-  def mock_input_count
-    input_count
-  end
-
-  def mock_output_count
-    output_count
+  def mock_set_defaults
+    set_defaults
   end
 
   def mock_create_inputs(n)
@@ -27,15 +23,9 @@ describe Circuits::Component do
 
   subject { MockComponent.new(outputs: outputs) }
 
-  describe '#input_count' do
+  describe '#set_defaults' do
     it 'is not implemented' do
-      expect { subject.mock_input_count }.to raise_error(NotImplementedError)
-    end
-  end
-
-  describe '#output_count' do
-    it 'is not implemented' do
-      expect { subject.mock_output_count }.to raise_error(NotImplementedError)
+      expect { subject.mock_set_defaults }.to raise_error(NotImplementedError)
     end
   end
 
@@ -49,26 +39,6 @@ describe Circuits::Component do
     it 'tocks the outputs' do
       expect(outputs[0]).to receive(:tock)
       subject.tock
-    end
-  end
-
-  describe '#create_inputs' do
-    before :each do
-      allow(subject).to receive(:input_count).and_return(2)
-    end
-
-    context 'when the given argument is less than the value of input count' do
-      it 'fails with an argument error' do
-        expect { subject.mock_create_inputs(0) }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'when given a valid number of inputs' do
-      [2, 4, 6].each do |n|
-        it "creates #{n} inputs" do
-          expect(subject.mock_create_inputs(n).size).to eq(n)
-        end
-      end
     end
   end
 end

--- a/spec/unit/circuits/terminal/input_spec.rb
+++ b/spec/unit/circuits/terminal/input_spec.rb
@@ -13,7 +13,6 @@ describe Circuits::Terminal::Input do
 
   describe '#initialize' do
     context 'when given an output' do
-
       subject { Circuits::Terminal::Input.new(output: output) }
 
       it 'sets the output' do


### PR DESCRIPTION
You can access terminals much tidier now `my_component.inputs[0]` => `my_component[:a]`

If a component has only one input it can be accessed by `my_component[:in]`, otherwise they are alphabetical `my_component[:a]`, `my_component[:b]`, etc..
A component with a single output will be available through `my_component[:out]` otherwise it follows the alphabet where inputs left off.

You can override this behavior by declaring `@port_mappings` like in `lib/circuits/component/sr_nor.rb`

I changed all the tests to use this where applicable.

To declare default input and output counts in a component you need to declare `@input_count` and `@output_count` respectively instead of functions as before.

I got rid of the raise when creating an input with less inputs than the default as this doesn't work with the new `set_defaults` function. Also an AND gate with one input might be useful as a buffer!